### PR TITLE
Basic Skyblock related events and example usages

### DIFF
--- a/src/main/java/io/github/skyblockcore/SkyblockCore.java
+++ b/src/main/java/io/github/skyblockcore/SkyblockCore.java
@@ -3,17 +3,22 @@ package io.github.skyblockcore;
 import io.github.skyblockcore.event.JoinSkyblockCallback;
 import io.github.skyblockcore.event.LeaveSkyblockCallback;
 import net.fabricmc.api.ClientModInitializer;
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.text.Text;
 import net.minecraft.util.ActionResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.Objects;
 
 public class SkyblockCore implements ClientModInitializer {
     public static final String ModID = "skyblockcore";
 
     private static boolean ON_SKYBLOCK = false;
     public static boolean isOnSkyblock() { return ON_SKYBLOCK; }
+    public static String getLocation() { return LOCATION; }
+    public static void setLocation(String newLocation) {
+        if (!Objects.equals(newLocation, LOCATION)) LOCATION = newLocation;
+    }
+    private static String LOCATION;
 
     public static final Logger LOGGER = LoggerFactory.getLogger(ModID);
 
@@ -26,6 +31,7 @@ public class SkyblockCore implements ClientModInitializer {
         });
         LeaveSkyblockCallback.EVENT.register(() -> {
             ON_SKYBLOCK = false;
+            LOCATION = null;
             return ActionResult.PASS;
         });
     }

--- a/src/main/java/io/github/skyblockcore/SkyblockCore.java
+++ b/src/main/java/io/github/skyblockcore/SkyblockCore.java
@@ -2,7 +2,10 @@ package io.github.skyblockcore;
 
 import io.github.skyblockcore.event.JoinSkyblockCallback;
 import io.github.skyblockcore.event.LeaveSkyblockCallback;
+import io.github.skyblockcore.event.LocationChangedCallback;
 import net.fabricmc.api.ClientModInitializer;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.text.Text;
 import net.minecraft.util.ActionResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -15,16 +18,13 @@ public class SkyblockCore implements ClientModInitializer {
     private static boolean ON_SKYBLOCK = false;
     public static boolean isOnSkyblock() { return ON_SKYBLOCK; }
     public static String getLocation() { return LOCATION; }
-    public static void setLocation(String newLocation) {
-        if (!Objects.equals(newLocation, LOCATION)) LOCATION = newLocation;
-    }
     private static String LOCATION;
 
     public static final Logger LOGGER = LoggerFactory.getLogger(ModID);
 
     @Override
     public void onInitializeClient() {
-        // example of event, TODO; move to better class
+        // example of events, TODO; move to better class
         JoinSkyblockCallback.EVENT.register(() -> {
             ON_SKYBLOCK = true;
             return ActionResult.PASS;
@@ -34,5 +34,9 @@ public class SkyblockCore implements ClientModInitializer {
             LOCATION = null;
             return ActionResult.PASS;
         });
+        LocationChangedCallback.EVENT.register(((oldLocation, newLocation) -> {
+            LOCATION = newLocation;
+            return ActionResult.PASS;
+        }));
     }
 }

--- a/src/main/java/io/github/skyblockcore/SkyblockCore.java
+++ b/src/main/java/io/github/skyblockcore/SkyblockCore.java
@@ -1,16 +1,26 @@
 package io.github.skyblockcore;
 
+import io.github.skyblockcore.event.JoinSkyblockCallback;
 import net.fabricmc.api.ClientModInitializer;
+import net.minecraft.util.ActionResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class SkyblockCore implements ClientModInitializer {
     public static final String ModID = "skyblockcore";
 
+    private static boolean ON_SKYBLOCK = false;
+    public static boolean isOnSkyblock() { return ON_SKYBLOCK; }
+
     public static final Logger LOGGER = LoggerFactory.getLogger(ModID);
 
     @Override
     public void onInitializeClient() {
-        System.out.println("Hello World");
+        // example of event, TODO; move to better class
+        JoinSkyblockCallback.EVENT.register(() -> {
+            ON_SKYBLOCK = true;
+            System.out.println("Skyblock joined");
+            return ActionResult.PASS;
+        });
     }
 }

--- a/src/main/java/io/github/skyblockcore/SkyblockCore.java
+++ b/src/main/java/io/github/skyblockcore/SkyblockCore.java
@@ -1,7 +1,10 @@
 package io.github.skyblockcore;
 
 import io.github.skyblockcore.event.JoinSkyblockCallback;
+import io.github.skyblockcore.event.LeaveSkyblockCallback;
 import net.fabricmc.api.ClientModInitializer;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.text.Text;
 import net.minecraft.util.ActionResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -19,7 +22,10 @@ public class SkyblockCore implements ClientModInitializer {
         // example of event, TODO; move to better class
         JoinSkyblockCallback.EVENT.register(() -> {
             ON_SKYBLOCK = true;
-            System.out.println("Skyblock joined");
+            return ActionResult.PASS;
+        });
+        LeaveSkyblockCallback.EVENT.register(() -> {
+            ON_SKYBLOCK = false;
             return ActionResult.PASS;
         });
     }

--- a/src/main/java/io/github/skyblockcore/SkyblockCore.java
+++ b/src/main/java/io/github/skyblockcore/SkyblockCore.java
@@ -4,13 +4,9 @@ import io.github.skyblockcore.event.JoinSkyblockCallback;
 import io.github.skyblockcore.event.LeaveSkyblockCallback;
 import io.github.skyblockcore.event.LocationChangedCallback;
 import net.fabricmc.api.ClientModInitializer;
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.text.Text;
 import net.minecraft.util.ActionResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.Objects;
 
 public class SkyblockCore implements ClientModInitializer {
     public static final String ModID = "skyblockcore";

--- a/src/main/java/io/github/skyblockcore/event/JoinSkyblockCallback.java
+++ b/src/main/java/io/github/skyblockcore/event/JoinSkyblockCallback.java
@@ -1,0 +1,21 @@
+package io.github.skyblockcore.event;
+
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+import net.minecraft.util.ActionResult;
+
+public interface JoinSkyblockCallback {
+
+    Event<JoinSkyblockCallback> EVENT = EventFactory.createArrayBacked(JoinSkyblockCallback.class,
+            (listeners) -> () -> {
+                for (JoinSkyblockCallback listener : listeners) {
+                    ActionResult result = listener.interact();
+
+                    if (result != ActionResult.PASS) return result;
+                }
+                return ActionResult.PASS;
+            });
+
+    ActionResult interact();
+
+}

--- a/src/main/java/io/github/skyblockcore/event/LeaveSkyblockCallback.java
+++ b/src/main/java/io/github/skyblockcore/event/LeaveSkyblockCallback.java
@@ -1,0 +1,21 @@
+package io.github.skyblockcore.event;
+
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+import net.minecraft.util.ActionResult;
+
+public interface LeaveSkyblockCallback {
+
+    Event<LeaveSkyblockCallback> EVENT = EventFactory.createArrayBacked(LeaveSkyblockCallback.class,
+            (listeners) -> () -> {
+                for (LeaveSkyblockCallback listener : listeners) {
+                    ActionResult result = listener.interact();
+
+                    if (result != ActionResult.PASS) return result;
+                }
+                return ActionResult.PASS;
+            });
+
+    ActionResult interact();
+
+}

--- a/src/main/java/io/github/skyblockcore/event/LocationChangedCallback.java
+++ b/src/main/java/io/github/skyblockcore/event/LocationChangedCallback.java
@@ -1,0 +1,21 @@
+package io.github.skyblockcore.event;
+
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+import net.minecraft.util.ActionResult;
+
+public interface LocationChangedCallback {
+
+    Event<LocationChangedCallback> EVENT = EventFactory.createArrayBacked(LocationChangedCallback.class,
+            (listeners) -> (oldLocation, newLocation) -> {
+                for (LocationChangedCallback listener : listeners) {
+                    ActionResult result = listener.interact(oldLocation, newLocation);
+
+                    if (result != ActionResult.PASS) return result;
+                }
+                return ActionResult.PASS;
+            });
+
+    ActionResult interact(String oldLocation, String newLocation);
+
+}

--- a/src/main/java/io/github/skyblockcore/mixin/ClientConnectionMixin.java
+++ b/src/main/java/io/github/skyblockcore/mixin/ClientConnectionMixin.java
@@ -1,0 +1,21 @@
+package io.github.skyblockcore.mixin;
+
+import io.github.skyblockcore.SkyblockCore;
+import io.github.skyblockcore.event.LeaveSkyblockCallback;
+import net.minecraft.network.ClientConnection;
+import net.minecraft.text.Text;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(ClientConnection.class)
+public class ClientConnectionMixin {
+
+    @Inject(method = "disconnect", at = @At("HEAD"))
+    void onDisconnect(Text disconnectReason, CallbackInfo ci) {
+        if (!SkyblockCore.isOnSkyblock()) return;
+        LeaveSkyblockCallback.EVENT.invoker().interact();
+    }
+
+}

--- a/src/main/java/io/github/skyblockcore/mixin/PlayNetworkHandlerMixin.java
+++ b/src/main/java/io/github/skyblockcore/mixin/PlayNetworkHandlerMixin.java
@@ -4,6 +4,8 @@ import com.google.common.collect.Sets;
 import io.github.skyblockcore.SkyblockCore;
 import io.github.skyblockcore.event.JoinSkyblockCallback;
 import io.github.skyblockcore.event.LeaveSkyblockCallback;
+import io.github.skyblockcore.event.LocationChangedCallback;
+import io.github.skyblockcore.util.TextUtils;
 import net.minecraft.client.network.ClientPlayNetworkHandler;
 import net.minecraft.client.world.ClientWorld;
 import net.minecraft.network.packet.s2c.play.DisconnectS2CPacket;
@@ -60,8 +62,10 @@ public class PlayNetworkHandlerMixin {
         for (ScoreboardPlayerScore score : scores) {
             String line = Team.decorateName(scoreboard.getPlayerTeam(score.getPlayerName()), Text.literal(score.getPlayerName())).getString();
             if (line.contains("\u23E3")) {
-                String split = line.split("\u23E3 ")[1];
-                SkyblockCore.setLocation(split.substring(0, split.length()-2));
+                String location = TextUtils.stripColorCodes(line.split("\u23E3 ")[1]);
+                if (location.equals(SkyblockCore.getLocation())) break;
+                LocationChangedCallback.EVENT.invoker().interact(SkyblockCore.getLocation(), location);
+                break;
             }
         }
     }

--- a/src/main/java/io/github/skyblockcore/mixin/PlayNetworkHandlerMixin.java
+++ b/src/main/java/io/github/skyblockcore/mixin/PlayNetworkHandlerMixin.java
@@ -5,26 +5,33 @@ import io.github.skyblockcore.SkyblockCore;
 import io.github.skyblockcore.event.JoinSkyblockCallback;
 import io.github.skyblockcore.event.LeaveSkyblockCallback;
 import net.minecraft.client.network.ClientPlayNetworkHandler;
+import net.minecraft.client.world.ClientWorld;
 import net.minecraft.network.packet.s2c.play.DisconnectS2CPacket;
 import net.minecraft.network.packet.s2c.play.ScoreboardObjectiveUpdateS2CPacket;
+import net.minecraft.scoreboard.Scoreboard;
+import net.minecraft.scoreboard.ScoreboardObjective;
+import net.minecraft.scoreboard.ScoreboardPlayerScore;
+import net.minecraft.scoreboard.Team;
 import net.minecraft.text.Text;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import java.util.Collection;
 import java.util.Set;
 
 @Mixin(ClientPlayNetworkHandler.class)
 public class PlayNetworkHandlerMixin {
 
+    @Shadow private ClientWorld world;
     private static final Set<String> SKYBLOCK_TITLES = Sets.newHashSet("SKYBLOCK", "\u7A7A\u5C9B\u751F\u5B58", "\u7A7A\u5CF6\u751F\u5B58");
 
     @Inject(method = "onScoreboardObjectiveUpdate", at = @At("TAIL"))
     void onScoreboardDisplay(ScoreboardObjectiveUpdateS2CPacket packet, CallbackInfo ci) {
         if (SkyblockCore.isOnSkyblock()) return;
         String header = packet.getDisplayName().getString();
-        System.out.println(header);
         for (String TITLE : SKYBLOCK_TITLES) {
             if (header.contains(TITLE)) JoinSkyblockCallback.EVENT.invoker().interact();
         }
@@ -40,6 +47,23 @@ public class PlayNetworkHandlerMixin {
     void onDisconnect(Text reason, CallbackInfo ci) {
         if (!SkyblockCore.isOnSkyblock()) return;
         LeaveSkyblockCallback.EVENT.invoker().interact();
+    }
+
+    @Inject(method = "onScoreboardObjectiveUpdate", at = @At("TAIL"))
+    void onScoreboardObjective(ScoreboardObjectiveUpdateS2CPacket packet, CallbackInfo ci) {
+        if (!SkyblockCore.isOnSkyblock()) return;
+        Scoreboard scoreboard = this.world.getScoreboard();
+        ScoreboardObjective objective = scoreboard.getObjectiveForSlot(Scoreboard.SIDEBAR_DISPLAY_SLOT_ID);
+        if (objective == null) return;
+
+        Collection<ScoreboardPlayerScore> scores = scoreboard.getAllPlayerScores(objective);
+        for (ScoreboardPlayerScore score : scores) {
+            String line = Team.decorateName(scoreboard.getPlayerTeam(score.getPlayerName()), Text.literal(score.getPlayerName())).getString();
+            if (line.contains("\u23E3")) {
+                String split = line.split("\u23E3 ")[1];
+                SkyblockCore.setLocation(split.substring(0, split.length()-2));
+            }
+        }
     }
 
 }

--- a/src/main/java/io/github/skyblockcore/mixin/PlayNetworkHandlerMixin.java
+++ b/src/main/java/io/github/skyblockcore/mixin/PlayNetworkHandlerMixin.java
@@ -3,8 +3,11 @@ package io.github.skyblockcore.mixin;
 import com.google.common.collect.Sets;
 import io.github.skyblockcore.SkyblockCore;
 import io.github.skyblockcore.event.JoinSkyblockCallback;
+import io.github.skyblockcore.event.LeaveSkyblockCallback;
 import net.minecraft.client.network.ClientPlayNetworkHandler;
+import net.minecraft.network.packet.s2c.play.DisconnectS2CPacket;
 import net.minecraft.network.packet.s2c.play.ScoreboardObjectiveUpdateS2CPacket;
+import net.minecraft.text.Text;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -25,6 +28,18 @@ public class PlayNetworkHandlerMixin {
         for (String TITLE : SKYBLOCK_TITLES) {
             if (header.contains(TITLE)) JoinSkyblockCallback.EVENT.invoker().interact();
         }
+    }
+
+    @Inject(method = "onDisconnect", at = @At("TAIL"))
+    void onDisconnect(DisconnectS2CPacket packet, CallbackInfo ci) {
+        if (!SkyblockCore.isOnSkyblock()) return;
+        LeaveSkyblockCallback.EVENT.invoker().interact();
+    }
+
+    @Inject(method = "onDisconnected", at = @At("TAIL"))
+    void onDisconnect(Text reason, CallbackInfo ci) {
+        if (!SkyblockCore.isOnSkyblock()) return;
+        LeaveSkyblockCallback.EVENT.invoker().interact();
     }
 
 }

--- a/src/main/java/io/github/skyblockcore/mixin/PlayNetworkHandlerMixin.java
+++ b/src/main/java/io/github/skyblockcore/mixin/PlayNetworkHandlerMixin.java
@@ -1,0 +1,30 @@
+package io.github.skyblockcore.mixin;
+
+import com.google.common.collect.Sets;
+import io.github.skyblockcore.SkyblockCore;
+import io.github.skyblockcore.event.JoinSkyblockCallback;
+import net.minecraft.client.network.ClientPlayNetworkHandler;
+import net.minecraft.network.packet.s2c.play.ScoreboardObjectiveUpdateS2CPacket;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.Set;
+
+@Mixin(ClientPlayNetworkHandler.class)
+public class PlayNetworkHandlerMixin {
+
+    private static final Set<String> SKYBLOCK_TITLES = Sets.newHashSet("SKYBLOCK", "\u7A7A\u5C9B\u751F\u5B58", "\u7A7A\u5CF6\u751F\u5B58");
+
+    @Inject(method = "onScoreboardObjectiveUpdate", at = @At("TAIL"))
+    void onScoreboardDisplay(ScoreboardObjectiveUpdateS2CPacket packet, CallbackInfo ci) {
+        if (SkyblockCore.isOnSkyblock()) return;
+        String header = packet.getDisplayName().getString();
+        System.out.println(header);
+        for (String TITLE : SKYBLOCK_TITLES) {
+            if (header.contains(TITLE)) JoinSkyblockCallback.EVENT.invoker().interact();
+        }
+    }
+
+}

--- a/src/main/java/io/github/skyblockcore/util/TextUtils.java
+++ b/src/main/java/io/github/skyblockcore/util/TextUtils.java
@@ -1,0 +1,16 @@
+package io.github.skyblockcore.util;
+
+public class TextUtils {
+
+    public static String stripColorCodes(String text) {
+        if (!text.contains("\u00A7")) return text;
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < text.length(); i++) {
+            char c = text.charAt(i);
+            if (c == '\u00A7') i++;
+            else sb.append(c);
+        }
+        return sb.toString();
+    }
+
+}

--- a/src/main/resources/skyblockcore.mixins.json
+++ b/src/main/resources/skyblockcore.mixins.json
@@ -4,6 +4,7 @@
   "package": "io.github.skyblockcore.mixin",
   "compatibilityLevel": "JAVA_17",
   "mixins": [
+    "ClientConnectionMixin"
   ],
   "client": [
     "ExampleMixin",

--- a/src/main/resources/skyblockcore.mixins.json
+++ b/src/main/resources/skyblockcore.mixins.json
@@ -6,7 +6,8 @@
   "mixins": [
   ],
   "client": [
-    "ExampleMixin"
+    "ExampleMixin",
+    "PlayNetworkHandlerMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
Adds the following:
- Join Skyblock event
- Leave Skyblock event
- Method that returns whether or not the player is on Skyblock
- Getter for Skyblock Location + implementation (pulled from sidebar)
- Skyblock Location Changed event