### PR TITLE
Fix for getting if you're on SKYBLOCK using skytils's method & README.MD update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,41 @@
-# SkyBlock-Core
-Centralized SkyBlock Mod for Settings, Menus, Localization, Events, etc.
+# SkyBlock Core
 
-Each mod will be it's own module on top of Skyblock-Core
+[![License](https://img.shields.io/badge/license-Apache--2.0-green)](https://github.com/SkyBlock-Central/SkyBlock-Core/blob/main/LICENSE)
+[![Discord](https://img.shields.io/badge/Discord-Click_Here-blue)](https://discord.gg/GzHcvZcu8m)
+## What is SkyBlock Core?
+
+SkyBlock Core is a centralized mod for SkyBlock settings, menus, localization, events, and more. It serves as a foundation for other SkyBlock mods by providing essential functionality and features. With SkyBlock-Core, you can easily build and extend your own SkyBlock experience.
+
+## Modules
+
+Each mod built on top of SkyBlock Core is its own module, allowing for modular and customizable SkyBlock gameplay. The modularity enables developers to add specific features and functionality to their SkyBlock experience while benefiting from the centralized core.
+
+## Getting Started
+
+To get started with SkyBlock-Core, you need Java 17 and Fabric 1.19x. Follow the steps below to set up the development environment:
+
+1. Have a working braincell (It is recommended to at least have `2` braincells.)
+2. Clone this repository: `git clone https://github.com/SkyBlock-Central/SkyBlock-Core.git`
+3. Open the project in your preferred Java IDE.
+4. Configure the project to use Java 17.
+5. Set up Fabric 1.19x as the modding framework.
+6. Explore the codebase and start building your own module on top of SkyBlock-Core.
+
+## Contributing
+
+Contributions are welcome! If you'd like to contribute to SkyBlock-Core, please follow these guidelines:
+
+- Fork the repository.
+- Create a new branch for your feature or bug fix.
+- Commit your changes and push the branch to your fork.
+- Open a pull request explaining your changes.
+
+Please ensure that your code follows the existing coding style and conventions.
+
+## License
+
+SkyBlock-Core is licensed under the [Apache License 2.0](https://github.com/SkyBlock-Central/SkyBlock-Core/blob/main/LICENSE). See the `LICENSE` file for more information.
+
+---
+
+© 2023 SkyBlock-Central. All rights reserved.

--- a/src/main/java/io/github/skyblockcore/mixin/PlayNetworkHandlerMixin.java
+++ b/src/main/java/io/github/skyblockcore/mixin/PlayNetworkHandlerMixin.java
@@ -8,6 +8,7 @@ import io.github.skyblockcore.event.LocationChangedCallback;
 import io.github.skyblockcore.util.TextUtils;
 import net.minecraft.client.network.ClientPlayNetworkHandler;
 import net.minecraft.client.world.ClientWorld;
+import net.minecraft.network.packet.s2c.play.ScoreboardDisplayS2CPacket;
 import net.minecraft.network.packet.s2c.play.ScoreboardObjectiveUpdateS2CPacket;
 import net.minecraft.scoreboard.Scoreboard;
 import net.minecraft.scoreboard.ScoreboardObjective;
@@ -25,7 +26,6 @@ import java.util.Set;
 
 @Mixin(ClientPlayNetworkHandler.class)
 public class PlayNetworkHandlerMixin {
-
     @Shadow private ClientWorld world;
     private static final Set<String> SKYBLOCK_TITLES = Sets.newHashSet("SKYBLOCK", "\u7A7A\u5C9B\u751F\u5B58", "\u7A7A\u5CF6\u751F\u5B58");
 
@@ -45,11 +45,12 @@ public class PlayNetworkHandlerMixin {
         if (onSkyblock) LeaveSkyblockCallback.EVENT.invoker().interact();
     }
 
-    @Inject(method = "onScoreboardObjectiveUpdate", at = @At("TAIL"))
-    void onScoreboardObjective(ScoreboardObjectiveUpdateS2CPacket packet, CallbackInfo ci) {
+    @Inject(method = "onScoreboardDisplay", at = @At("TAIL"))
+    void onScoreboardDisplay(ScoreboardDisplayS2CPacket packet, CallbackInfo ci) {
         if (!SkyblockCore.isOnSkyblock()) return;
+
         Scoreboard scoreboard = this.world.getScoreboard();
-        ScoreboardObjective objective = scoreboard.getObjectiveForSlot(Scoreboard.SIDEBAR_DISPLAY_SLOT_ID);
+        ScoreboardObjective objective = scoreboard.getNullableObjective(packet.getName());
         if (objective == null) return;
 
         Collection<ScoreboardPlayerScore> scores = scoreboard.getAllPlayerScores(objective);
@@ -63,5 +64,4 @@ public class PlayNetworkHandlerMixin {
             }
         }
     }
-
 }


### PR DESCRIPTION
changed the method of getting if you're on skyblock from random scoreboard thing to 
S3DPacketDisplayScoreboard
This didn't break for skytils last April fools so hopefully admins don't learn and change how they do it 

Changed README.md to look a lot better (Used ai for a tiny bit of it because formatting SUCKSSS) 

it did build with the changes but no clue how I would actually test it (Last I checked its not a mod, I could be wrong tho) 